### PR TITLE
Local ip address

### DIFF
--- a/config-sample.json
+++ b/config-sample.json
@@ -18,7 +18,8 @@
             {
                 "name": "MP1",
                 "type": "MP",
-                "mac": "CA:32:4F:77:D2:21"
+                "mac": "CA:32:4F:77:D2:21",
+                "local_ip_address": "192.168.0.1"
             }
         ]
     }]

--- a/index.js
+++ b/index.js
@@ -115,12 +115,12 @@ BroadlinkAccessory.prototype = {
     // b: broadlink
     discover: function(b) {
         b.discover(this.local_ip_address);
-    },
+    }
 
     getSPState: function(callback) {
         var self = this;
         var b = new broadlink();
-        discover(b);
+        self.discover(b);
 
         b.on("deviceReady", (dev) => {
             if (self.mac_buff(self.mac).equals(dev.mac) || dev.host.address == self.ip) {
@@ -142,7 +142,7 @@ BroadlinkAccessory.prototype = {
             }
         });
         var checkAgainSP = setInterval(function() {
-            discover(b);
+            self.discover(b);
         }, 1000)
 
     },
@@ -150,7 +150,7 @@ BroadlinkAccessory.prototype = {
     setSPState: function(state, callback) {
         var self = this;
         var b = new broadlink();
-        discover(b);
+        self.discover(b);
 
         self.log("set SP state: " + state);
         if (state) {
@@ -170,7 +170,7 @@ BroadlinkAccessory.prototype = {
                     }
                 });
                 var checkAgainSPset = setInterval(function() {
-                    discover(b);
+                    self.discover(b);
                 }, 1000)
             }
         } else {
@@ -188,7 +188,7 @@ BroadlinkAccessory.prototype = {
                     }
                 });
                 var checkAgainSPset = setInterval(function() {
-                    discover(b);
+                    self.discover(b);
                 }, 1000)
             } else {
                 return callback(null, false)
@@ -201,7 +201,7 @@ BroadlinkAccessory.prototype = {
         var b = new broadlink();
         var s_index = self.sname[1];
         self.log("checking status for " + self.name);
-        discover(b);
+        self.discover(b);
         b.on("deviceReady", (dev) => {
             //self.log("detected device type:" + dev.type + " @ " + dev.host.address);
             if (self.mac_buff(self.mac).equals(dev.mac) || dev.host.address == self.ip) {
@@ -229,14 +229,14 @@ BroadlinkAccessory.prototype = {
         });
         var checkAgain = setInterval(function() {
             //self.log("Discovering Again for Status... " + self.sname);
-            discover(b);
+            self.discover(b);
         }, 1000)
 
 
     },
 
     setMPstate: function(state, callback) {
-        var self = this
+        var self = this;
         var s_index = self.sname[1];
         var b = new broadlink();
 
@@ -245,7 +245,7 @@ BroadlinkAccessory.prototype = {
             if (self.powered) {
                 return callback(null, true);
             } else {
-                discover(b);
+                self.discover(b);
                 b.on("deviceReady", (dev) => {
                     if (self.mac_buff(self.mac).equals(dev.mac) || dev.host.address == self.ip) {
                         self.log(self.sname + " is ON!");
@@ -260,12 +260,12 @@ BroadlinkAccessory.prototype = {
                 });
                 var checkAgainSet = setInterval(function() {
                     //self.log("Discovering Again for Set Command... " + self.sname);
-                    discover(b);
+                    self.discover(b);
                 }, 1000)
             }
         } else {
             if (self.powered) {
-                discover(b);
+                self.discover(b);
                 b.on("deviceReady", (dev) => {
                     if (self.mac_buff(self.mac).equals(dev.mac) || dev.host.address == self.ip) {
                         self.log(self.sname + " is OFF!");
@@ -280,7 +280,7 @@ BroadlinkAccessory.prototype = {
                 });
                 var checkAgainSet = setInterval(function() {
                     //self.log("Discovering Again for Set Command... " + self.sname);
-                    discover(b);
+                    self.discover(b);
                 }, 1000)
             } else {
                 return callback(null, false)

--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ BroadlinkAccessory.prototype = {
     // b: broadlink
     discover: function(b) {
         b.discover(this.local_ip_address);
-    }
+    },
 
     getSPState: function(callback) {
         var self = this;

--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ function BroadlinkAccessory(log, config) {
     this.ip = config.ip;
     this.mac = config.mac;
     this.powered = false;
+    this.local_ip_address = config.local_ip_address;
 
     if (!this.ip && !this.mac) throw new Error("You must provide a config value for 'ip' or 'mac'.");
 
@@ -111,10 +112,15 @@ BroadlinkAccessory.prototype = {
         return services;
     },
 
+    // b: broadlink
+    discover: function(b) {
+        b.discover(this.local_ip_address);
+    }
+
     getSPState: function(callback) {
         var self = this;
         var b = new broadlink();
-        b.discover();
+        discover(b);
 
         b.on("deviceReady", (dev) => {
             if (self.mac_buff(self.mac).equals(dev.mac) || dev.host.address == self.ip) {
@@ -136,7 +142,7 @@ BroadlinkAccessory.prototype = {
             }
         });
         var checkAgainSP = setInterval(function() {
-            b.discover();
+            discover(b);
         }, 1000)
 
     },
@@ -144,7 +150,7 @@ BroadlinkAccessory.prototype = {
     setSPState: function(state, callback) {
         var self = this;
         var b = new broadlink();
-        b.discover();
+        discover(b);
 
         self.log("set SP state: " + state);
         if (state) {
@@ -164,7 +170,7 @@ BroadlinkAccessory.prototype = {
                     }
                 });
                 var checkAgainSPset = setInterval(function() {
-                    b.discover();
+                    discover(b);
                 }, 1000)
             }
         } else {
@@ -182,7 +188,7 @@ BroadlinkAccessory.prototype = {
                     }
                 });
                 var checkAgainSPset = setInterval(function() {
-                    b.discover();
+                    discover(b);
                 }, 1000)
             } else {
                 return callback(null, false)
@@ -195,7 +201,7 @@ BroadlinkAccessory.prototype = {
         var b = new broadlink();
         var s_index = self.sname[1];
         self.log("checking status for " + self.name);
-        b.discover();
+        discover(b);
         b.on("deviceReady", (dev) => {
             //self.log("detected device type:" + dev.type + " @ " + dev.host.address);
             if (self.mac_buff(self.mac).equals(dev.mac) || dev.host.address == self.ip) {
@@ -223,7 +229,7 @@ BroadlinkAccessory.prototype = {
         });
         var checkAgain = setInterval(function() {
             //self.log("Discovering Again for Status... " + self.sname);
-            b.discover();
+            discover(b);
         }, 1000)
 
 
@@ -239,7 +245,7 @@ BroadlinkAccessory.prototype = {
             if (self.powered) {
                 return callback(null, true);
             } else {
-                b.discover();
+                discover(b);
                 b.on("deviceReady", (dev) => {
                     if (self.mac_buff(self.mac).equals(dev.mac) || dev.host.address == self.ip) {
                         self.log(self.sname + " is ON!");
@@ -254,12 +260,12 @@ BroadlinkAccessory.prototype = {
                 });
                 var checkAgainSet = setInterval(function() {
                     //self.log("Discovering Again for Set Command... " + self.sname);
-                    b.discover();
+                    discover(b);
                 }, 1000)
             }
         } else {
             if (self.powered) {
-                b.discover();
+                discover(b);
                 b.on("deviceReady", (dev) => {
                     if (self.mac_buff(self.mac).equals(dev.mac) || dev.host.address == self.ip) {
                         self.log(self.sname + " is OFF!");
@@ -274,7 +280,7 @@ BroadlinkAccessory.prototype = {
                 });
                 var checkAgainSet = setInterval(function() {
                     //self.log("Discovering Again for Set Command... " + self.sname);
-                    b.discover();
+                    discover(b);
                 }, 1000)
             } else {
                 return callback(null, false)


### PR DESCRIPTION
This update added a "local_ip_address" option in config. This option is quite useful if multiple network interfaces exist and the one connecting to the target device is not the first. Also node's os.networkInterfaces cannot find all interfaces in some cases where providing a binding address may become a must (issue https://github.com/nodejs/node/issues/498).

To make this patch work, updating https://github.com/smka/broadlinkjs-sm is mandatory (however it will not break either if the update does not happen). I also submitted a pull request there https://github.com/smka/broadlinkjs-sm/pull/2.

## Use/test case with homebridge-broadlink-platform:

My raspberry pi connected to a router via eth0 along with my iphone. The raspberry pi also has a wireless interface wlan0 which I set as an AP. The network on eth0 has ip 192.168.0.10 and the network on wlan0 has ip 192.168.42.1. An SP1 device connected to wlan0.

Now if without the "local_ip_address" option, when sending the broadcast message to 255.255.255.255, the packet will be sent through only one (random) interface (see https://stackoverflow.com/questions/683624/udp-broadcast-on-all-interfaces) and perhaps under the network 192.168.0. Thus , it will not reach my SP1. By this update we can provide local_ip_address as 192.168.42.1 to solve the problem.

## Changes

The changes are simple: get the config and fill it to broadlink.discover. A method is extracted to remove duplicates.